### PR TITLE
fix(security): bump vulnerable deps (patch/minor)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6934,9 +6934,10 @@
       "integrity": "sha512-9ItEpeu15hW5m8jKdriL+BQrgwDTXEL9pn4SkillWFu73ZNNNQ2BKKLS+ZHv2vC9UkNhosAeyfxOf/5OSeTCPA=="
     },
     "node_modules/elliptic": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.5.tgz",
-      "integrity": "sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==",
+      "version": "6.5.7",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
   },
   "engines": {
     "node": ">=18.0"
+  },
+  "overrides": {
+    "elliptic": "6.5.7"
   }
 }


### PR DESCRIPTION
## Contexte
Bumps de sécurité **patch/minor** (même majeur, faible régression) vers les versions patchées : dépendances directes bumpées, transitives via `overrides`. Lockfile régénéré.

## Paquets
- `elliptic` → `6.5.7`

_Findings Aikido — audit sécurité. Aucune modification de code applicatif._

🤖 Generated with [Claude Code](https://claude.com/claude-code)